### PR TITLE
Fix: Getting latest tag by sorting

### DIFF
--- a/.github/workflows/GetLatestTag.yml
+++ b/.github/workflows/GetLatestTag.yml
@@ -48,7 +48,7 @@ jobs:
             echo "TAG=$(git describe --tag)" >> $GITHUB_ENV
           elif '${{ inputs.environment == 'STG' && (startsWith(github.ref_name, 'hotfix/') || startsWith(github.ref_name, 'release/')) }}'
           then
-            echo "TAG=$(git describe --match "$(echo '${{ github.ref_name }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')-rc*" --abbrev=0 --tags $(git rev-list --tags --max-count=1))"  >> $GITHUB_ENV
+            echo "TAG=$(git tag --sort=-v:refname | grep "$(echo '${{ github.ref_name }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')-rc" | head -n 1)"  >> $GITHUB_ENV
           else
             echo ""
           fi


### PR DESCRIPTION
### 문제상황

https://github.com/ggqcompany/back-node-master-gateway-server/actions/runs/4574335331/jobs/8075887891

Gateway 배포 시 `1.4.0-rc.2+230329` 태그가 있는데도 불구하고 태그를 찾지 못해 `1.4.0-rc.3+230329`가 아닌 `1.4.0-rc.1+230329`로 생성하려고 하면서 에러 발생

### 발생원인

기존에 사용하던 `git rev-list --tags --max-count=1` 명령어는 태그가 연결된 가장 최근 커밋을 의미한다.
이 커밋이 가리키는 태그가 없는 경우 문제가 발생할 수 있다.
gateway의 경우 `git describe --match `에 의해 `1.4.0-rc.2+230329`를 정상적으로 찾았으나,
`git rev-list --tags --max-count=1`로 바로 직전에 배포한 hotfix 태그(`1.3.1+hotfix.230331`)의 커밋을 가져오게 된다.

즉 hotfix 태그(`1.3.1+hotfix.230331`) 커밋과 연결된 `1.4.0-rc.*`로 생성된 가장 최근 태그를 가져오라는 명령어를 입력하게 되는데,
hotfix는 main에서만 branch out되었고, release/1.4.0 브랜치는 develop에서만 branch out 되어 main과 develop간 연결되어 있는 부분이 없어 발생한 이슈로 보인다. (hotfix 발행 시 develop 브랜치로 머지하여 main과 develop graph가 연결되는 경우 문제 발생하지 않는다)

### 해결 방안

최근 커밋과 연결된 태그 패턴으로 검색하지 않고, 버전명과 일치한 rc 태그를 찾아 sorting하여 rc버전이 가장 큰 태그를 가져오도록 변경하였다.
`git tag --sort=-v:refname | grep "$(echo '${{ github.ref_name }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')-rc" | head -n 1`

예: `git tag --sort=-v:refname | grep "1.4.0-rc" | head -n 1`


### 테스트 완료
- rc 태그가 없을 때 rc.1 태그로 생성하는가? ✅ 
- rc.1과 rc.10이 있을 때 rc.10을 검색하는가? ✅ 
- 이전 발행 tag commit 브랜치와 연결이 되어 있지 않아도 태그를 정상적으로 검색하는가? ✅ 

| AS-IS | TO-BE |
|-|-|
| ![image](https://user-images.githubusercontent.com/106716812/229957653-518dadda-2dd6-4d16-b12a-56a06d3d0e8b.png) | ![image](https://user-images.githubusercontent.com/106716812/229957813-2571e476-314e-476c-ac3b-7f2218753401.png) |
| `2.0.0-rc.1` 태그가 있음에도 불구하고 <br>직전의 hotfix tag commit과 브랜치가 이어져 있지 않아 <br>`No tags can describe` 에러 발생 | 동일한 상황에서 변경 후 `2.0.0-rc.1` 태그 검색 확인 |
